### PR TITLE
Fix for when the out folder hasn't been created

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "randos": "node ."
+    "randos": "mkdir -p out && node ."
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
the npm run randos command requires that there is a folder called out in the root of the project.