### PR TITLE
Remove unnecessary await

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ async function svgToPng(name) {
     const src = `./out/${name}.svg`;
     const dest = `./out/${name}.png`;
 
-    const img = await sharp(src);
-    const resized = await img.resize(1024);
+    const img = sharp(src);
+    const resized = img.resize(1024);
     await resized.toFile(dest);
 }
 


### PR DESCRIPTION
Those functions do not return promises, therefore the `await` keyword is unnecessary.